### PR TITLE
Add database cleanup feature

### DIFF
--- a/falcon.php
+++ b/falcon.php
@@ -43,6 +43,7 @@ new Components\Cache\Manager;
 
 if ( is_admin() ) {
 	new Core;
+	new Components\Cleanup;
 } else {
 	new Header;
 	new Media;

--- a/src/Components/Cleanup.php
+++ b/src/Components/Cleanup.php
@@ -1,0 +1,266 @@
+<?php
+namespace Falcon\Components;
+
+class Cleanup {
+	public function __construct() {
+		add_filter( 'falcon_settings_tabs', [ $this, 'add_tab' ] );
+		add_filter( 'falcon_settings_tab_panes', [ $this, 'add_tab_pane' ] );
+		add_action( 'wp_ajax_falcon_run_cleanup', [ $this, 'run' ] );
+		add_action( 'wp_ajax_falcon_cleanup_counts', [ $this, 'get_counts_ajax' ] );
+	}
+
+	public function add_tab( array $tabs ): array {
+		$tabs['cleanup'] = __( 'Cleanup', 'falcon' );
+		return $tabs;
+	}
+
+	public function add_tab_pane( array $panes ): array {
+		$panes['cleanup'] = $this->get_tab_pane();
+		return $panes;
+	}
+
+	private function get_tab_pane(): string {
+		ob_start();
+		printf( '<div class="e-tabPane" data-tab="%s">', esc_attr( 'cleanup' ) );
+		include FALCON_DIR . '/views/settings/tabs/cleanup.php';
+		do_action( 'falcon_settings_tab_cleanup' );
+		echo '</div>';
+		return ob_get_clean();
+	}
+
+	public function run(): void {
+		check_ajax_referer( 'cleanup' );
+
+		$items = ! empty( $_POST['items'] ) ? (array) wp_unslash( $_POST['items'] ) : [];
+		$items = array_map( 'sanitize_text_field', $items );
+
+		if ( empty( $items ) ) {
+			wp_send_json_error( __( 'Please select at least one item to clean.', 'falcon' ) );
+		}
+
+		$results = [];
+		foreach ( $items as $item ) {
+			$method = str_replace( '-', '_', $item );
+			if ( method_exists( __CLASS__, $method ) ) {
+				$cleaned = self::$method();
+				if ( $cleaned > 0 ) {
+					$labels   = self::get_labels();
+					$label    = $labels[ $item ] ?? $item;
+					/* translators: %1$d - number of items, %2$s - item type */
+					$results[] = sprintf( __( 'Cleaned %1$d %2$s.', 'falcon' ), $cleaned, strtolower( $label ) );
+				}
+			}
+		}
+
+		if ( empty( $results ) ) {
+			wp_send_json_success( __( 'Nothing to clean. Your database is already clean!', 'falcon' ) );
+		}
+
+		wp_send_json_success( implode( '<br>', $results ) );
+	}
+
+	public function get_counts_ajax(): void {
+		check_ajax_referer( 'cleanup' );
+		wp_send_json_success( self::get_counts() );
+	}
+
+	public static function get_labels(): array {
+		return [
+			'revisions'             => __( 'Revisions', 'falcon' ),
+			'auto_drafts'           => __( 'Auto Drafts', 'falcon' ),
+			'trashed_posts'         => __( 'Trashed Posts', 'falcon' ),
+			'spam_comments'         => __( 'Spam Comments', 'falcon' ),
+			'trashed_comments'      => __( 'Trashed Comments', 'falcon' ),
+			'expired_transients'    => __( 'Expired Transients', 'falcon' ),
+			'orphaned_post_meta'    => __( 'Orphaned Post Meta', 'falcon' ),
+			'orphaned_comment_meta' => __( 'Orphaned Comment Meta', 'falcon' ),
+			'orphaned_user_meta'    => __( 'Orphaned User Meta', 'falcon' ),
+			'orphaned_term_meta'    => __( 'Orphaned Term Meta', 'falcon' ),
+			'orphaned_post_terms'   => __( 'Orphaned Post Terms', 'falcon' ),
+			'unused_terms'          => __( 'Unused Terms', 'falcon' ),
+			'optimize_tables'       => __( 'Optimize Database Tables', 'falcon' ),
+		];
+	}
+
+	public static function get_counts(): array {
+		global $wpdb;
+		return [
+			'revisions'             => (int) $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->posts WHERE post_type = 'revision'" ),
+			'auto_drafts'           => (int) $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->posts WHERE post_status = 'auto-draft'" ),
+			'trashed_posts'         => (int) $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->posts WHERE post_status = 'trash'" ),
+			'spam_comments'         => (int) $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->comments WHERE comment_approved = 'spam'" ),
+			'trashed_comments'      => (int) $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->comments WHERE comment_approved = 'trash'" ),
+			'expired_transients'    => self::count_expired_transients(),
+			'orphaned_post_meta'    => (int) $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->postmeta pm LEFT JOIN $wpdb->posts p ON p.ID = pm.post_id WHERE p.ID IS NULL" ),
+			'orphaned_comment_meta' => (int) $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->commentmeta cm LEFT JOIN $wpdb->comments c ON c.comment_ID = cm.comment_id WHERE c.comment_ID IS NULL" ),
+			'orphaned_user_meta'    => (int) $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->usermeta um LEFT JOIN $wpdb->users u ON u.ID = um.user_id WHERE u.ID IS NULL" ),
+			'orphaned_term_meta'    => (int) $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->termmeta tm LEFT JOIN $wpdb->terms t ON t.term_id = tm.term_id WHERE t.term_id IS NULL" ),
+			'orphaned_post_terms'   => (int) $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->term_relationships tr LEFT JOIN $wpdb->posts p ON p.ID = tr.object_id WHERE p.ID IS NULL" ),
+			'unused_terms'          => (int) $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->terms t WHERE t.term_id NOT IN (SELECT term_id FROM $wpdb->term_taxonomy WHERE count > 0)" ),
+			'optimize_tables'       => 0,
+		];
+	}
+
+	private static function count_expired_transients(): int {
+		global $wpdb;
+		$count = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*) FROM $wpdb->options WHERE (option_name LIKE %s OR option_name LIKE %s) AND option_value < %d",
+				$wpdb->esc_like( '_transient_timeout_' ) . '%',
+				$wpdb->esc_like( '_site_transient_timeout_' ) . '%',
+				time()
+			)
+		);
+		return $count;
+	}
+
+	private static function revisions(): int {
+		global $wpdb;
+		$count = self::count( 'revisions' );
+		if ( $count > 0 ) {
+			$wpdb->delete( $wpdb->posts, [ 'post_type' => 'revision' ] );
+		}
+		return $count;
+	}
+
+	private static function auto_drafts(): int {
+		global $wpdb;
+		$count = self::count( 'auto_drafts' );
+		if ( $count > 0 ) {
+			$wpdb->delete( $wpdb->posts, [ 'post_status' => 'auto-draft' ] );
+		}
+		return $count;
+	}
+
+	private static function trashed_posts(): int {
+		global $wpdb;
+		$ids = $wpdb->get_col( "SELECT ID FROM $wpdb->posts WHERE post_status = 'trash'" );
+		foreach ( $ids as $id ) {
+			wp_delete_post( (int) $id, true );
+		}
+		return count( $ids );
+	}
+
+	private static function spam_comments(): int {
+		global $wpdb;
+		$ids = $wpdb->get_col( "SELECT comment_ID FROM $wpdb->comments WHERE comment_approved = 'spam'" );
+		foreach ( $ids as $id ) {
+			wp_delete_comment( (int) $id, true );
+		}
+		return count( $ids );
+	}
+
+	private static function trashed_comments(): int {
+		global $wpdb;
+		$ids = $wpdb->get_col( "SELECT comment_ID FROM $wpdb->comments WHERE comment_approved = 'trash'" );
+		foreach ( $ids as $id ) {
+			wp_delete_comment( (int) $id, true );
+		}
+		return count( $ids );
+	}
+
+	private static function expired_transients(): int {
+		global $wpdb;
+		$count = self::count( 'expired_transients' );
+		if ( $count > 0 ) {
+			$time = time();
+			$wpdb->query(
+				$wpdb->prepare(
+					"DELETE a, b FROM $wpdb->options a, $wpdb->options b
+					WHERE a.option_name LIKE %s
+					AND b.option_name = CONCAT( '_transient_timeout_', SUBSTRING( a.option_name, 12 ) )
+					AND b.option_value < %d",
+					'_transient_%',
+					$time
+				)
+			);
+			$wpdb->query(
+				$wpdb->prepare(
+					"DELETE a, b FROM $wpdb->options a, $wpdb->options b
+					WHERE a.option_name LIKE %s
+					AND b.option_name = CONCAT( '_site_transient_timeout_', SUBSTRING( a.option_name, 18 ) )
+					AND b.option_value < %d",
+					'_site_transient_%',
+					$time
+				)
+			);
+		}
+		return $count;
+	}
+
+	private static function orphaned_post_meta(): int {
+		global $wpdb;
+		$count = self::count( 'orphaned_post_meta' );
+		if ( $count > 0 ) {
+			$wpdb->query( "DELETE pm FROM $wpdb->postmeta pm LEFT JOIN $wpdb->posts p ON p.ID = pm.post_id WHERE p.ID IS NULL" );
+		}
+		return $count;
+	}
+
+	private static function orphaned_comment_meta(): int {
+		global $wpdb;
+		$count = self::count( 'orphaned_comment_meta' );
+		if ( $count > 0 ) {
+			$wpdb->query( "DELETE cm FROM $wpdb->commentmeta cm LEFT JOIN $wpdb->comments c ON c.comment_ID = cm.comment_id WHERE c.comment_ID IS NULL" );
+		}
+		return $count;
+	}
+
+	private static function orphaned_user_meta(): int {
+		global $wpdb;
+		$count = self::count( 'orphaned_user_meta' );
+		if ( $count > 0 ) {
+			$wpdb->query( "DELETE um FROM $wpdb->usermeta um LEFT JOIN $wpdb->users u ON u.ID = um.user_id WHERE u.ID IS NULL" );
+		}
+		return $count;
+	}
+
+	private static function orphaned_term_meta(): int {
+		global $wpdb;
+		$count = self::count( 'orphaned_term_meta' );
+		if ( $count > 0 ) {
+			$wpdb->query( "DELETE tm FROM $wpdb->termmeta tm LEFT JOIN $wpdb->terms t ON t.term_id = tm.term_id WHERE t.term_id IS NULL" );
+		}
+		return $count;
+	}
+
+	private static function orphaned_post_terms(): int {
+		global $wpdb;
+		$count = self::count( 'orphaned_post_terms' );
+		if ( $count > 0 ) {
+			$wpdb->query( "DELETE tr FROM $wpdb->term_relationships tr LEFT JOIN $wpdb->posts p ON p.ID = tr.object_id WHERE p.ID IS NULL" );
+		}
+		return $count;
+	}
+
+	private static function unused_terms(): int {
+		global $wpdb;
+		$count    = self::count( 'unused_terms' );
+		if ( $count > 0 ) {
+			$term_ids = $wpdb->get_col( "SELECT t.term_id FROM $wpdb->terms t WHERE t.term_id NOT IN (SELECT term_id FROM $wpdb->term_taxonomy WHERE count > 0)" );
+			if ( ! empty( $term_ids ) ) {
+				$taxonomies = $wpdb->get_results(
+					"SELECT tt.term_id, tt.taxonomy FROM $wpdb->term_taxonomy tt WHERE tt.term_id IN (" . implode( ',', array_map( 'intval', $term_ids ) ) . ')'
+				);
+				foreach ( $taxonomies as $row ) {
+					wp_delete_term( (int) $row->term_id, $row->taxonomy );
+				}
+			}
+		}
+		return $count;
+	}
+
+	private static function optimize_tables(): int {
+		global $wpdb;
+		$tables = $wpdb->get_col( "SHOW TABLES LIKE '{$wpdb->prefix}%'" );
+		foreach ( $tables as $table ) {
+			$wpdb->query( "OPTIMIZE TABLE $table" ); // phpcs:ignore
+		}
+		return count( $tables );
+	}
+
+	private static function count( string $item ): int {
+		$counts = self::get_counts();
+		return $counts[ $item ] ?? 0;
+	}
+}

--- a/src/Components/Cleanup.php
+++ b/src/Components/Cleanup.php
@@ -96,7 +96,7 @@ class Cleanup {
 			'orphaned_user_meta'    => (int) $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->usermeta um LEFT JOIN $wpdb->users u ON u.ID = um.user_id WHERE u.ID IS NULL" ),
 			'orphaned_term_meta'    => (int) $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->termmeta tm LEFT JOIN $wpdb->terms t ON t.term_id = tm.term_id WHERE t.term_id IS NULL" ),
 			'orphaned_post_terms'   => (int) $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->term_relationships tr LEFT JOIN $wpdb->posts p ON p.ID = tr.object_id WHERE p.ID IS NULL" ),
-			'unused_terms'          => (int) $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->terms t WHERE t.term_id NOT IN (SELECT term_id FROM $wpdb->term_taxonomy WHERE count > 0)" ),
+			'unused_terms'          => (int) $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->terms t LEFT JOIN $wpdb->term_taxonomy tt ON tt.term_id = t.term_id WHERE tt.term_id IS NULL OR tt.count = 0" ),
 			'optimize_tables'       => 0,
 		];
 	}
@@ -168,9 +168,11 @@ class Cleanup {
 				$wpdb->prepare(
 					"DELETE a, b FROM $wpdb->options a, $wpdb->options b
 					WHERE a.option_name LIKE %s
+					AND a.option_name NOT LIKE %s
 					AND b.option_name = CONCAT( '_transient_timeout_', SUBSTRING( a.option_name, 12 ) )
 					AND b.option_value < %d",
 					'_transient_%',
+					'_transient_timeout_%',
 					$time
 				)
 			);
@@ -178,9 +180,11 @@ class Cleanup {
 				$wpdb->prepare(
 					"DELETE a, b FROM $wpdb->options a, $wpdb->options b
 					WHERE a.option_name LIKE %s
-					AND b.option_name = CONCAT( '_site_transient_timeout_', SUBSTRING( a.option_name, 18 ) )
+					AND a.option_name NOT LIKE %s
+					AND b.option_name = CONCAT( '_site_transient_timeout_', SUBSTRING( a.option_name, 17 ) )
 					AND b.option_value < %d",
 					'_site_transient_%',
+					'_site_transient_timeout_%',
 					$time
 				)
 			);
@@ -235,16 +239,14 @@ class Cleanup {
 
 	private static function unused_terms(): int {
 		global $wpdb;
-		$count    = self::count( 'unused_terms' );
+		$count = self::count( 'unused_terms' );
 		if ( $count > 0 ) {
 			$term_ids = $wpdb->get_col( "SELECT t.term_id FROM $wpdb->terms t WHERE t.term_id NOT IN (SELECT term_id FROM $wpdb->term_taxonomy WHERE count > 0)" );
 			if ( ! empty( $term_ids ) ) {
-				$taxonomies = $wpdb->get_results(
-					"SELECT tt.term_id, tt.taxonomy FROM $wpdb->term_taxonomy tt WHERE tt.term_id IN (" . implode( ',', array_map( 'intval', $term_ids ) ) . ')'
-				);
-				foreach ( $taxonomies as $row ) {
-					wp_delete_term( (int) $row->term_id, $row->taxonomy );
-				}
+				$ids = implode( ',', array_map( 'intval', $term_ids ) );
+				$wpdb->query( "DELETE FROM $wpdb->term_relationships WHERE term_taxonomy_id IN (SELECT term_taxonomy_id FROM $wpdb->term_taxonomy WHERE term_id IN ($ids))" );
+				$wpdb->query( "DELETE FROM $wpdb->term_taxonomy WHERE term_id IN ($ids)" );
+				$wpdb->query( "DELETE FROM $wpdb->terms WHERE term_id IN ($ids)" );
 			}
 		}
 		return $count;

--- a/src/Components/Cleanup.php
+++ b/src/Components/Cleanup.php
@@ -2,6 +2,8 @@
 namespace Falcon\Components;
 
 class Cleanup {
+	private static ?array $counts = null;
+
 	public function __construct() {
 		add_filter( 'falcon_settings_tabs', [ $this, 'add_tab' ] );
 		add_filter( 'falcon_settings_tab_panes', [ $this, 'add_tab_pane' ] );
@@ -39,52 +41,78 @@ class Cleanup {
 		}
 
 		$results = [];
+		$actions = [
+			'optimize_tables' => __( 'Optimized', 'falcon' ),
+		];
+		$nouns   = [
+			'optimize_tables' => __( 'database tables', 'falcon' ),
+		];
 		foreach ( $items as $item ) {
 			$method = str_replace( '-', '_', $item );
-			if ( method_exists( __CLASS__, $method ) ) {
-				$cleaned = self::$method();
-				if ( $cleaned > 0 ) {
-					$labels   = self::get_labels();
-					$label    = $labels[ $item ] ?? $item;
-					/* translators: %1$d - number of items, %2$s - item type */
-					$results[] = sprintf( __( 'Cleaned %1$d %2$s.', 'falcon' ), $cleaned, strtolower( $label ) );
-				}
+			if ( ! method_exists( __CLASS__, $method ) ) {
+				continue;
 			}
+			$cleaned = self::$method();
+			if ( $cleaned <= 0 ) {
+				continue;
+			}
+			$verb = $actions[ $method ] ?? __( 'Cleaned', 'falcon' );
+			$noun = $nouns[ $method ] ?? strtolower( self::get_labels()[ $item ] ?? $item );
+			$results[] = sprintf(
+				/* translators: %1$s - action verb, %2$d - number of items, %3$s - item type */
+				__( '%1$s %2$d %3$s.', 'falcon' ),
+				$verb,
+				$cleaned,
+				$noun
+			);
 		}
 
 		if ( empty( $results ) ) {
-			wp_send_json_success( __( 'Nothing to clean. Your database is already clean!', 'falcon' ) );
+			wp_send_json_success( [
+				'message' => __( 'Nothing to clean. Your database is already clean!', 'falcon' ),
+				'counts'  => self::get_counts(),
+			] );
 		}
 
-		wp_send_json_success( implode( '<br>', $results ) );
+		self::$counts = null;
+		wp_send_json_success( [
+			'message' => implode( '<br>', $results ),
+			'counts'  => self::get_counts(),
+		] );
 	}
 
 	public function get_counts_ajax(): void {
 		check_ajax_referer( 'cleanup' );
+		self::$counts = null;
 		wp_send_json_success( self::get_counts() );
 	}
 
 	public static function get_labels(): array {
 		return [
 			'revisions'             => __( 'Revisions', 'falcon' ),
-			'auto_drafts'           => __( 'Auto Drafts', 'falcon' ),
-			'trashed_posts'         => __( 'Trashed Posts', 'falcon' ),
-			'spam_comments'         => __( 'Spam Comments', 'falcon' ),
-			'trashed_comments'      => __( 'Trashed Comments', 'falcon' ),
-			'expired_transients'    => __( 'Expired Transients', 'falcon' ),
-			'orphaned_post_meta'    => __( 'Orphaned Post Meta', 'falcon' ),
-			'orphaned_comment_meta' => __( 'Orphaned Comment Meta', 'falcon' ),
-			'orphaned_user_meta'    => __( 'Orphaned User Meta', 'falcon' ),
-			'orphaned_term_meta'    => __( 'Orphaned Term Meta', 'falcon' ),
-			'orphaned_post_terms'   => __( 'Orphaned Post Terms', 'falcon' ),
-			'unused_terms'          => __( 'Unused Terms', 'falcon' ),
-			'optimize_tables'       => __( 'Optimize Database Tables', 'falcon' ),
+			'auto_drafts'           => __( 'Auto drafts', 'falcon' ),
+			'trashed_posts'         => __( 'Trashed posts', 'falcon' ),
+			'spam_comments'         => __( 'Spam comments', 'falcon' ),
+			'trashed_comments'      => __( 'Trashed comments', 'falcon' ),
+			'expired_transients'    => __( 'Expired transients', 'falcon' ),
+			'orphaned_post_meta'    => __( 'Orphaned post meta', 'falcon' ),
+			'orphaned_comment_meta' => __( 'Orphaned comment meta', 'falcon' ),
+			'orphaned_user_meta'    => __( 'Orphaned user meta', 'falcon' ),
+			'orphaned_term_meta'    => __( 'Orphaned term meta', 'falcon' ),
+			'orphaned_post_terms'   => __( 'Orphaned post terms', 'falcon' ),
+			'unused_terms'          => __( 'Unused terms', 'falcon' ),
+			'optimize_tables'       => __( 'Optimize database tables', 'falcon' ),
 		];
 	}
 
 	public static function get_counts(): array {
 		global $wpdb;
-		return [
+
+		if ( self::$counts !== null ) {
+			return self::$counts;
+		}
+
+		return self::$counts = [
 			'revisions'             => (int) $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->posts WHERE post_type = 'revision'" ),
 			'auto_drafts'           => (int) $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->posts WHERE post_status = 'auto-draft'" ),
 			'trashed_posts'         => (int) $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->posts WHERE post_status = 'trash'" ),
@@ -117,18 +145,20 @@ class Cleanup {
 	private static function revisions(): int {
 		global $wpdb;
 		$count = self::count( 'revisions' );
-		if ( $count > 0 ) {
-			$wpdb->delete( $wpdb->posts, [ 'post_type' => 'revision' ] );
+		if ( $count <= 0 ) {
+			return 0;
 		}
+		$wpdb->delete( $wpdb->posts, [ 'post_type' => 'revision' ] );
 		return $count;
 	}
 
 	private static function auto_drafts(): int {
 		global $wpdb;
 		$count = self::count( 'auto_drafts' );
-		if ( $count > 0 ) {
-			$wpdb->delete( $wpdb->posts, [ 'post_status' => 'auto-draft' ] );
+		if ( $count <= 0 ) {
+			return 0;
 		}
+		$wpdb->delete( $wpdb->posts, [ 'post_status' => 'auto-draft' ] );
 		return $count;
 	}
 
@@ -162,93 +192,101 @@ class Cleanup {
 	private static function expired_transients(): int {
 		global $wpdb;
 		$count = self::count( 'expired_transients' );
-		if ( $count > 0 ) {
-			$time = time();
-			$wpdb->query(
-				$wpdb->prepare(
-					"DELETE a, b FROM $wpdb->options a, $wpdb->options b
-					WHERE a.option_name LIKE %s
-					AND a.option_name NOT LIKE %s
-					AND b.option_name = CONCAT( '_transient_timeout_', SUBSTRING( a.option_name, 12 ) )
-					AND b.option_value < %d",
-					'_transient_%',
-					'_transient_timeout_%',
-					$time
-				)
-			);
-			$wpdb->query(
-				$wpdb->prepare(
-					"DELETE a, b FROM $wpdb->options a, $wpdb->options b
-					WHERE a.option_name LIKE %s
-					AND a.option_name NOT LIKE %s
-					AND b.option_name = CONCAT( '_site_transient_timeout_', SUBSTRING( a.option_name, 17 ) )
-					AND b.option_value < %d",
-					'_site_transient_%',
-					'_site_transient_timeout_%',
-					$time
-				)
-			);
+		if ( $count <= 0 ) {
+			return 0;
 		}
+		$time = time();
+		$wpdb->query(
+			$wpdb->prepare(
+				"DELETE a, b FROM $wpdb->options a, $wpdb->options b
+				WHERE a.option_name LIKE %s
+				AND a.option_name NOT LIKE %s
+				AND b.option_name = CONCAT( '_transient_timeout_', SUBSTRING( a.option_name, 12 ) )
+				AND b.option_value < %d",
+				'_transient_%',
+				'_transient_timeout_%',
+				$time
+			)
+		);
+		$wpdb->query(
+			$wpdb->prepare(
+				"DELETE a, b FROM $wpdb->options a, $wpdb->options b
+				WHERE a.option_name LIKE %s
+				AND a.option_name NOT LIKE %s
+				AND b.option_name = CONCAT( '_site_transient_timeout_', SUBSTRING( a.option_name, 17 ) )
+				AND b.option_value < %d",
+				'_site_transient_%',
+				'_site_transient_timeout_%',
+				$time
+			)
+		);
 		return $count;
 	}
 
 	private static function orphaned_post_meta(): int {
 		global $wpdb;
 		$count = self::count( 'orphaned_post_meta' );
-		if ( $count > 0 ) {
-			$wpdb->query( "DELETE pm FROM $wpdb->postmeta pm LEFT JOIN $wpdb->posts p ON p.ID = pm.post_id WHERE p.ID IS NULL" );
+		if ( $count <= 0 ) {
+			return 0;
 		}
+		$wpdb->query( "DELETE pm FROM $wpdb->postmeta pm LEFT JOIN $wpdb->posts p ON p.ID = pm.post_id WHERE p.ID IS NULL" );
 		return $count;
 	}
 
 	private static function orphaned_comment_meta(): int {
 		global $wpdb;
 		$count = self::count( 'orphaned_comment_meta' );
-		if ( $count > 0 ) {
-			$wpdb->query( "DELETE cm FROM $wpdb->commentmeta cm LEFT JOIN $wpdb->comments c ON c.comment_ID = cm.comment_id WHERE c.comment_ID IS NULL" );
+		if ( $count <= 0 ) {
+			return 0;
 		}
+		$wpdb->query( "DELETE cm FROM $wpdb->commentmeta cm LEFT JOIN $wpdb->comments c ON c.comment_ID = cm.comment_id WHERE c.comment_ID IS NULL" );
 		return $count;
 	}
 
 	private static function orphaned_user_meta(): int {
 		global $wpdb;
 		$count = self::count( 'orphaned_user_meta' );
-		if ( $count > 0 ) {
-			$wpdb->query( "DELETE um FROM $wpdb->usermeta um LEFT JOIN $wpdb->users u ON u.ID = um.user_id WHERE u.ID IS NULL" );
+		if ( $count <= 0 ) {
+			return 0;
 		}
+		$wpdb->query( "DELETE um FROM $wpdb->usermeta um LEFT JOIN $wpdb->users u ON u.ID = um.user_id WHERE u.ID IS NULL" );
 		return $count;
 	}
 
 	private static function orphaned_term_meta(): int {
 		global $wpdb;
 		$count = self::count( 'orphaned_term_meta' );
-		if ( $count > 0 ) {
-			$wpdb->query( "DELETE tm FROM $wpdb->termmeta tm LEFT JOIN $wpdb->terms t ON t.term_id = tm.term_id WHERE t.term_id IS NULL" );
+		if ( $count <= 0 ) {
+			return 0;
 		}
+		$wpdb->query( "DELETE tm FROM $wpdb->termmeta tm LEFT JOIN $wpdb->terms t ON t.term_id = tm.term_id WHERE t.term_id IS NULL" );
 		return $count;
 	}
 
 	private static function orphaned_post_terms(): int {
 		global $wpdb;
 		$count = self::count( 'orphaned_post_terms' );
-		if ( $count > 0 ) {
-			$wpdb->query( "DELETE tr FROM $wpdb->term_relationships tr LEFT JOIN $wpdb->posts p ON p.ID = tr.object_id WHERE p.ID IS NULL" );
+		if ( $count <= 0 ) {
+			return 0;
 		}
+		$wpdb->query( "DELETE tr FROM $wpdb->term_relationships tr LEFT JOIN $wpdb->posts p ON p.ID = tr.object_id WHERE p.ID IS NULL" );
 		return $count;
 	}
 
 	private static function unused_terms(): int {
 		global $wpdb;
 		$count = self::count( 'unused_terms' );
-		if ( $count > 0 ) {
-			$term_ids = $wpdb->get_col( "SELECT t.term_id FROM $wpdb->terms t WHERE t.term_id NOT IN (SELECT term_id FROM $wpdb->term_taxonomy WHERE count > 0)" );
-			if ( ! empty( $term_ids ) ) {
-				$ids = implode( ',', array_map( 'intval', $term_ids ) );
-				$wpdb->query( "DELETE FROM $wpdb->term_relationships WHERE term_taxonomy_id IN (SELECT term_taxonomy_id FROM $wpdb->term_taxonomy WHERE term_id IN ($ids))" );
-				$wpdb->query( "DELETE FROM $wpdb->term_taxonomy WHERE term_id IN ($ids)" );
-				$wpdb->query( "DELETE FROM $wpdb->terms WHERE term_id IN ($ids)" );
-			}
+		if ( $count <= 0 ) {
+			return 0;
 		}
+		$term_ids = $wpdb->get_col( "SELECT t.term_id FROM $wpdb->terms t WHERE t.term_id NOT IN (SELECT term_id FROM $wpdb->term_taxonomy WHERE count > 0)" );
+		if ( empty( $term_ids ) ) {
+			return 0;
+		}
+		$ids = implode( ',', array_map( 'intval', $term_ids ) );
+		$wpdb->query( "DELETE FROM $wpdb->term_relationships WHERE term_taxonomy_id IN (SELECT term_taxonomy_id FROM $wpdb->term_taxonomy WHERE term_id IN ($ids))" );
+		$wpdb->query( "DELETE FROM $wpdb->term_taxonomy WHERE term_id IN ($ids)" );
+		$wpdb->query( "DELETE FROM $wpdb->terms WHERE term_id IN ($ids)" );
 		return $count;
 	}
 

--- a/src/Components/Cleanup.php
+++ b/src/Components/Cleanup.php
@@ -33,6 +33,10 @@ class Cleanup {
 	public function run(): void {
 		check_ajax_referer( 'cleanup' );
 
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( __( 'You do not have permission to perform this action.', 'falcon' ) );
+		}
+
 		$items = ! empty( $_POST['items'] ) ? (array) wp_unslash( $_POST['items'] ) : [];
 		$items = array_map( 'sanitize_text_field', $items );
 
@@ -83,6 +87,11 @@ class Cleanup {
 
 	public function get_counts_ajax(): void {
 		check_ajax_referer( 'cleanup' );
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( __( 'You do not have permission to perform this action.', 'falcon' ) );
+		}
+
 		self::$counts = null;
 		wp_send_json_success( self::get_counts() );
 	}

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -98,12 +98,13 @@ class Settings {
 		wp_enqueue_style( 'falcon', FALCON_URL . 'assets/settings.css', [], filemtime( FALCON_DIR . '/assets/settings.css' ) );
 		wp_enqueue_script( 'falcon', FALCON_URL . 'assets/settings.js', [], filemtime( FALCON_DIR . '/assets/settings.js' ), true );
 		wp_localize_script( 'falcon', 'Falcon', [
-			'nonce'        => wp_create_nonce( 'save' ),
-			'nonce_email'  => wp_create_nonce( 'send-email' ),
-			'nonce_cache'  => wp_create_nonce( 'clear-cache' ),
-			'nonce_import' => wp_create_nonce( 'import' ),
-			'saving'       => __( 'Saving...', 'falcon' ),
-			'save'         => __( 'Save Changes', 'falcon' ),
+			'nonce'          => wp_create_nonce( 'save' ),
+			'nonce_email'    => wp_create_nonce( 'send-email' ),
+			'nonce_cache'    => wp_create_nonce( 'clear-cache' ),
+			'nonce_import'   => wp_create_nonce( 'import' ),
+			'nonce_cleanup'  => wp_create_nonce( 'cleanup' ),
+			'saving'         => __( 'Saving...', 'falcon' ),
+			'save'           => __( 'Save Changes', 'falcon' ),
 		] );
 	}
 

--- a/views/settings/tabs/cleanup.php
+++ b/views/settings/tabs/cleanup.php
@@ -26,9 +26,9 @@ $items  = array_keys( $labels );
 	<button type="button" id="run-cleanup" class="button button-primary">
 		<?php esc_html_e( 'Run Cleanup', 'falcon' ); ?>
 	</button>
-	<span id="cleanup-message" class="message hidden"></span>
 	<span class="spinner" style="float: none; margin: 0;"></span>
 </div>
+<span id="cleanup-message" class="message hidden" style="margin-top: 10px; display: block;"></span>
 
 <script>
 {
@@ -48,9 +48,8 @@ $items  = array_keys( $labels );
 		button.disabled = true;
 		button.classList.add( 'disabled' );
 		spinner.classList.add( 'is-active' );
-		message.classList.remove( 'hidden' );
-		message.textContent = '<?php echo esc_js( __( 'Cleaning...', 'falcon' ) ); ?>';
 		message.className = 'message';
+		message.classList.add( 'hidden' );
 
 		const formData = new FormData();
 		formData.append( 'action', 'falcon_run_cleanup' );
@@ -66,23 +65,14 @@ $items  = array_keys( $labels );
 
 				message.className = 'message';
 				message.classList.add( 'notice', response.success ? 'notice-success' : 'notice-error' );
-				message.innerHTML = response.data;
+				message.innerHTML = response.data.message ?? response.data;
 
-				if ( response.success ) {
-					const fd = new FormData();
-					fd.append( 'action', 'falcon_cleanup_counts' );
-					fd.append( '_ajax_nonce', Falcon.nonce_cleanup );
-					fetch( ajaxurl, { method: 'POST', body: fd } )
-						.then( r => r.json() )
-						.then( data => {
-							if ( data.success ) {
-								document.querySelectorAll( '.cleanup-count' ).forEach( el => {
-									const checkbox = el.closest( '.featureBox' ).querySelector( '.cleanup-checkbox' );
-									const newCount = data.data[ checkbox.value ] ?? 0;
-									el.textContent = `(${ newCount })`;
-								} );
-							}
-						} );
+				if ( response.success && response.data.counts ) {
+					document.querySelectorAll( '.cleanup-count' ).forEach( el => {
+						const checkbox = el.closest( '.featureBox' ).querySelector( '.cleanup-checkbox' );
+						const newCount = response.data.counts[ checkbox.value ] ?? 0;
+						el.textContent = `(${ newCount })`;
+					} );
 				}
 			} );
 	} );

--- a/views/settings/tabs/cleanup.php
+++ b/views/settings/tabs/cleanup.php
@@ -1,0 +1,90 @@
+<?php
+use Falcon\Components\Cleanup;
+
+$labels = Cleanup::get_labels();
+$counts = Cleanup::get_counts();
+$items  = array_keys( $labels );
+?>
+<p><?php esc_html_e( 'Select items to clean up from your database. All items are selected by default.', 'falcon' ); ?></p>
+
+<?php foreach ( $items as $item ) : ?>
+	<div class="featureBox">
+		<label class="featureBox_switch">
+			<input class="featureBox_input cleanup-checkbox" type="checkbox" name="cleanup_items[]" value="<?= esc_attr( $item ); ?>" checked>
+			<span class="featureBox_icon"></span>
+		</label>
+		<div class="featureBox_body">
+			<div class="featureBox_title">
+				<?= esc_html( $labels[ $item ] ); ?>
+				<span class="cleanup-count">(<?= esc_html( $counts[ $item ] ); ?>)</span>
+			</div>
+		</div>
+	</div>
+<?php endforeach; ?>
+
+<div style="margin-top: 20px; display: flex; align-items: center; gap: 10px;">
+	<button type="button" id="run-cleanup" class="button button-primary">
+		<?php esc_html_e( 'Run Cleanup', 'falcon' ); ?>
+	</button>
+	<span id="cleanup-message" class="message hidden"></span>
+	<span class="spinner" style="float: none; margin: 0;"></span>
+</div>
+
+<script>
+{
+	const button = document.getElementById( 'run-cleanup' );
+	const message = document.getElementById( 'cleanup-message' );
+	const spinner = button.parentElement.querySelector( '.spinner' );
+
+	button.addEventListener( 'click', () => {
+		const checkboxes = document.querySelectorAll( '.cleanup-checkbox:checked' );
+		const items = Array.from( checkboxes ).map( cb => cb.value );
+
+		if ( items.length === 0 ) {
+			alert( '<?php echo esc_js( __( 'Please select at least one item to clean.', 'falcon' ) ); ?>' );
+			return;
+		}
+
+		button.disabled = true;
+		button.classList.add( 'disabled' );
+		spinner.classList.add( 'is-active' );
+		message.classList.remove( 'hidden' );
+		message.textContent = '<?php echo esc_js( __( 'Cleaning...', 'falcon' ) ); ?>';
+		message.className = 'message';
+
+		const formData = new FormData();
+		formData.append( 'action', 'falcon_run_cleanup' );
+		formData.append( '_ajax_nonce', Falcon.nonce_cleanup );
+		items.forEach( item => formData.append( 'items[]', item ) );
+
+		fetch( ajaxurl, { method: 'POST', body: formData } )
+			.then( response => response.json() )
+			.then( response => {
+				button.disabled = false;
+				button.classList.remove( 'disabled' );
+				spinner.classList.remove( 'is-active' );
+
+				message.className = 'message';
+				message.classList.add( 'notice', response.success ? 'notice-success' : 'notice-error' );
+				message.innerHTML = response.data;
+
+				if ( response.success ) {
+					const fd = new FormData();
+					fd.append( 'action', 'falcon_cleanup_counts' );
+					fd.append( '_ajax_nonce', Falcon.nonce_cleanup );
+					fetch( ajaxurl, { method: 'POST', body: fd } )
+						.then( r => r.json() )
+						.then( data => {
+							if ( data.success ) {
+								document.querySelectorAll( '.cleanup-count' ).forEach( el => {
+									const checkbox = el.closest( '.featureBox' ).querySelector( '.cleanup-checkbox' );
+									const newCount = data.data[ checkbox.value ] ?? 0;
+									el.textContent = `(${ newCount })`;
+								} );
+							}
+						} );
+				}
+			} );
+	} );
+}
+</script>


### PR DESCRIPTION
New Cleanup tab in settings with 13 cleanup types:

- Revisions, Auto drafts, Trashed posts, Spam comments, Trashed comments
- Expired transients
- Orphaned post/comment/user/term meta, Orphaned post terms
- Unused terms, Optimize database tables

All checkboxes checked by default. AJAX-driven with live count display and capability check for admins.